### PR TITLE
PVA-5685 Change timesnap version to our original one in timecut

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "commander": "^2.11.0",
-    "timesnap": "0.3.0"
+    "timesnap": "github:open8inc/timesnap"
   },
   "devDependencies": {
     "eslint": "^6.8.0"


### PR DESCRIPTION
### Description
I need to change some configuration in `timesnap` which `timecut` depends on because for some reason the chromium used in `timesnap` doesn't work well with `pkg`. To accomplish this, I temporarily changed the version in `package.json`

details: https://github.com/nigow/timesnap/commit/c70937737f5b1ce1bb623c0a0b59a2a6f0701b67